### PR TITLE
Cleanup - squid:S1118 - Utility classes should not have public constr…

### DIFF
--- a/src/main/java/io/cslinmiso/line/utils/Utility.java
+++ b/src/main/java/io/cslinmiso/line/utils/Utility.java
@@ -70,13 +70,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * 
  * @author Trey Lin
  */
-public class Utility {
+public final class Utility {
 
   private static final String UTL_8 = "UTF-8";
 
   // 分割的tag
   public static final String splitTag = String.valueOf('\002');
 
+  private Utility() throws InstantiationException {
+    throw new InstantiationException("This utility class is not created for instantiation");
+  }
 
   public static boolean isEmptyObject(JSONObject object) {
     return object.names() == null;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat