### PR TITLE
Cleanup - squid:S1149 - Synchronized classes Vector, Hashtable, Stack…

### DIFF
--- a/src/main/java/io/cslinmiso/line/utils/Utility.java
+++ b/src/main/java/io/cslinmiso/line/utils/Utility.java
@@ -158,7 +158,7 @@ public class Utility {
   }
 
   public static String getQueryString(Map target) {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     for (Object key : target.keySet()) {
       if ("_".equals(key)) continue;
       String[] t = (String[]) target.get(key);
@@ -185,7 +185,7 @@ public class Utility {
       byte[] passBytes = pass.getBytes();
       md.reset();
       byte[] digested = md.digest(passBytes);
-      StringBuffer sb = new StringBuffer();
+      StringBuilder sb = new StringBuilder();
       for (int i = 0; i < digested.length; i++) {
         sb.append(Integer.toHexString(0xff & digested[i]));
       }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1149

Please let me know if you have any questions.

M-Ezzat