### PR TITLE
Cleanup - squid:S1943 - Classes and methods that rely on the default …

### DIFF
--- a/src/main/java/io/cslinmiso/line/api/impl/LineApiImpl.java
+++ b/src/main/java/io/cslinmiso/line/api/impl/LineApiImpl.java
@@ -38,6 +38,7 @@ import io.cslinmiso.line.utils.Utility;
 
 import java.io.InputStream;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyFactory;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.RSAPublicKeySpec;
@@ -223,7 +224,7 @@ public class LineApiImpl implements LineApi {
     String tmpMsg =
         (char) (sessionKey.length()) + sessionKey + (char) (id.length()) + id
             + (char) (password.length()) + password;
-    String message = new String(tmpMsg.getBytes(), java.nio.charset.StandardCharsets.UTF_8);
+    String message = new String(tmpMsg.getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8);
     String[] keyArr = json.get("rsa_key").split(",");
     String keyName = keyArr[0];
     String n = keyArr[1];
@@ -237,7 +238,7 @@ public class LineApiImpl implements LineApi {
     RSAPublicKey publicKey = (RSAPublicKey) keyFactory.generatePublic(pubKeySpec);
     Cipher cipher = Cipher.getInstance("RSA/ECB/PKCS1Padding");
     cipher.init(Cipher.ENCRYPT_MODE, publicKey);
-    byte[] enBytes = cipher.doFinal(message.getBytes());
+    byte[] enBytes = cipher.doFinal(message.getBytes(StandardCharsets.UTF_8));
     String encryptString = Hex.encodeHexString(enBytes);
 
     THttpClient transport = new THttpClient(LINE_HTTP_URL);

--- a/src/main/java/io/cslinmiso/line/utils/Utility.java
+++ b/src/main/java/io/cslinmiso/line/utils/Utility.java
@@ -42,6 +42,7 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.text.SimpleDateFormat;
@@ -182,7 +183,7 @@ public class Utility {
   public static String cryptWithMD5(String pass) {
     try {
       MessageDigest md = MessageDigest.getInstance("MD5");
-      byte[] passBytes = pass.getBytes();
+      byte[] passBytes = pass.getBytes(StandardCharsets.UTF_8);
       md.reset();
       byte[] digested = md.digest(passBytes);
       StringBuffer sb = new StringBuffer();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1943 - Classes and methods that rely on the default system encoding should not be used

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1943

Please let me know if you have any questions.

M-Ezzat